### PR TITLE
fix: 解决 node@18.19.0 导致的 tsx load error

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: lts/Hydrogen
+          node-version: 18.18.2
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
当前 lts/Hydrogen 版本是 18.19.0 会导致以下错误（[完整日志](https://github.com/enpitsuLin/skland-daily-attendance/files/13594117/attendance.logs.zip)）

```
> skland-daily-attendance@1.0.0 attendance /home/runner/work/skland-daily-attendance/skland-daily-attendance
> tsx main.ts


node:internal/process/esm_loader:40
      internalBinding('errors').triggerUncaughtException(
                                ^
Error: tsx must be loaded with --import instead of --loader
The --loader flag was deprecated in Node v20.6.0
    at Q (file:///home/runner/work/skland-daily-attendance/skland-daily-attendance/node_modules/.pnpm/tsx@4.6.0/node_modules/tsx/dist/esm/index.mjs:1:1793)
    at Hooks.addCustomLoader (node:internal/modules/esm/hooks:202:24)
    at Hooks.register (node:internal/modules/esm/hooks:[16](https://github.com/moeyua/skland-daily-attendance/actions/runs/7119789151/job/19393884882#step:8:17)8:16)
    at async initializeHooks (node:internal/modules/esm/utils:167:5)
    at async customizedModuleWorker (node:internal/modules/esm/worker:104:24)

Node.js v[18](https://github.com/moeyua/skland-daily-attendance/actions/runs/7119789151/job/19393884882#step:8:19).[19](https://github.com/moeyua/skland-daily-attendance/actions/runs/7119789151/job/19393884882#step:8:20).0
 ELIFECYCLE  Command failed with exit code 1.
Error: Process completed with exit code 1.
```
可以参考 #https://github.com/backstage/backstage/issues/21738

暂时可以将 node 版本回退并锁定为 18.8.2 来规避这个问题。
